### PR TITLE
Jacoco test report depends on test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,10 @@ jacoco {
     toolVersion = jacocoVersion
 }
 
+jacocoTestReport {
+    dependsOn test
+}
+
 jacocoTestCoverageVerification {
     violationRules {
         rule {


### PR DESCRIPTION
before jacoco generates report tests must be run, otherwise `gradle jacocoTestReport` does not generate a report