### PR TITLE
Enable PMD rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,17 @@ pmd {
     ignoreFailures = false
     // TODO: targetJdk = 17 -- there is no defined property for this
     toolVersion = pmdVersion
+
+    consoleOutput = true
+    rulesMinimumPriority = 5
+
+
+    // custom-rules.xml contains editable rule set
+    // you can use it to adjust rules for your own project
+    ruleSets = [
+            rootProject.file("config/pmd/custom-rules.xml")
+    ]
+
 }
 
 spotbugs {

--- a/config/pmd/custom-rules.xml
+++ b/config/pmd/custom-rules.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Rules" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>
+        Custom rules to use on the project
+        The source of rule sets
+        https://github.com/pmd/pmd/tree/master/pmd-java/src/main/resources/category/java
+    </description>
+
+    <!-- There is right place to disable or configure some rules -->
+    <rule ref="category/java/bestpractices.xml"/>
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="CommentDefaultAccessModifier"/>
+    </rule>
+    <rule ref="category/java/design.xml">
+        <!-- The rule requires manual configuration -->
+        <exclude name="LoosePackageCoupling"/>
+        <!-- Is not applicable for modern coding style -->
+        <exclude name="LawOfDemeter"/>
+    </rule>
+    <rule ref="category/java/documentation.xml"/>
+    <rule ref="category/java/errorprone.xml"/>
+    <rule ref="category/java/multithreading.xml"/>
+    <rule ref="category/java/performance.xml"/>
+    <rule ref="category/java/security.xml"/>
+
+    <!-- Uncomment this if do want to exclude tests classes from analysis -->
+    <!-- <exclude-pattern>.*/src/test/.*</exclude-pattern> -->
+
+</ruleset>

--- a/src/integrationTest/java/demo/ApplicationTest.java
+++ b/src/integrationTest/java/demo/ApplicationTest.java
@@ -6,10 +6,20 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNor
 import static demo.Application.main;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ApplicationTest {
-    /** <strong>Use case</strong>: the application runs normally. */
+/**
+ * Just an example of Unit test.
+ */
+@SuppressWarnings({
+        "PMD.AtLeastOneConstructor",
+        "PMD.SignatureDeclareThrowsException"
+})
+class ApplicationTest {
+
+    /**
+     * <strong>Use case</strong>: the application runs normally.
+     **/
     @Test
-    public void shouldRun() throws Exception {
+    void shouldRun() throws Exception {
         final var out = tapSystemOutNormalized(() -> {
             main("Hello", "world!");
         });

--- a/src/test/java/demo/ApplicationIT.java
+++ b/src/test/java/demo/ApplicationIT.java
@@ -3,13 +3,19 @@ package demo;
 import org.junit.jupiter.api.Test;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
-import static demo.Application.main;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ApplicationIT {
+/**
+ * Integration test for the application.
+ */
+@SuppressWarnings({
+        "PMD.AtLeastOneConstructor",
+        "PMD.SignatureDeclareThrowsException"
+})
+class ApplicationIT {
     /** <strong>Use case</strong>: the application runs normally. */
     @Test
-    public void shouldRun() throws Exception {
+    void shouldRun() throws Exception {
         final var out = tapSystemOutNormalized(Application::main);
 
         assertThat(out).isEqualTo("TheFoo(label=I AM FOOCUTUS OF BORG)\n");

--- a/src/test/java/demo/TheFooTest.java
+++ b/src/test/java/demo/TheFooTest.java
@@ -10,7 +10,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 
+/**
+ * An example of test class.
+ */
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
+@SuppressWarnings({
+        "PMD.TooManyStaticImports",
+        "PMD.AtLeastOneConstructor"
+})
 class TheFooTest {
     @Test
     void shouldKnowTheFoo() {


### PR DESCRIPTION
PMD requires explicitly set which rules should be followed. Also, it is quite handy to create a custom ruleset and configure built-in PMD rules.
Also, due to PMD rules being switched off the commit fixes some PMD errors and suppress others :)

Hi Brian, let me know if u ok with the commit and I will fix maven build as well