### PR TITLE
Remove the testsets plugin, use native Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1727,8 +1727,8 @@ for your project.
 If you'd like to keep your integration tests in a separate source root from unit
 tests, consider these plugins:
 
-* For Gradle, use [_Gradle TestSets
-  Plugin_](https://github.com/unbroken-dome/gradle-testsets-plugin)
+* For Gradle, use [native Gradle to add new test
+  sets](https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests)
 * For Maven, use
   the [Maven Failsafe Plugin](https://maven.apache.org/failsafe/maven-failsafe-plugin/)
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ plugins {
     id "com.dorongold.task-tree"
     id "com.github.ben-manes.versions" // Try the `dependencyUpdates` task
     id "java" // Gradle support for Java
-    id "org.unbroken-dome.test-sets" // Alternative roots such an integration tests
     id "checkstyle" // To check that code follow style standards
     id "pmd" // Static analysis based on source (does not check compiled code)
     id "com.github.spotbugs" // Static analysis based on compiled code (does not check source)
@@ -75,6 +74,20 @@ dependencies {
     }
 }
 
+sourceSets {
+    integrationTest {
+        compileClasspath += sourceSets.main.output
+        compileClasspath += sourceSets.test.output
+        runtimeClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.test.output
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
 // TODO: Work around GitHub issue #54
 configurations.pmd {
     resolutionStrategy {
@@ -98,18 +111,26 @@ test {
     finalizedBy jacocoTestReport
 }
 
+tasks.register('integrationTest', Test) {
+    description = 'Runs integration tests.'
+    group = 'verification'
+
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    shouldRunAfter test
+
+    testLogging {
+        events "passed"
+    }
+}
+
+check.dependsOn integrationTest
+
 tasks.withType(Test) {
     // Quieter builds when JUL is in use (you or another library or tool)
     // TODO: Keep builds noisy in CI
     systemProperty "java.util.logging.config.file",
             "$projectDir/config/logging.properties"
-}
-
-testSets {
-    integrationTest
-}
-
-tasks.withType(Test) {
     // This idiom ensures JUnit5 for integration tests, not just unit tests
     useJUnitPlatform()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,5 +28,4 @@ spotbugsPluginVersion=5.0.14
 spotbugsVersion=4.7.3
 systemLambdaVersion=1.2.1
 taskTreePluginVersion=2.1.1
-testSetsPluginVersion=4.0.0
 versionsPluginVersion=0.46.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,6 @@ pluginManagement {
         id "info.solidsoft.pitest" version "$pitestPluginVersion"
         id "org.kordamp.gradle.jdeps" version "$jdepsPluginVersion"
         id "org.owasp.dependencycheck" version "$dependencyCheckPluginVersion"
-        id "org.unbroken-dome.test-sets" version "$testSetsPluginVersion"
     }
 }
 


### PR DESCRIPTION
The very excellent unbroken-dome testsets plugin did the Gradle build configuration for us.
With Gradle 8, it has stopped working, and held back this project from upgrading Gradle.

References:
- https://github.com/binkley/modern-java-practices/issues/358
- https://github.com/unbroken-dome/gradle-testsets-plugin/issues/131
- https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests