### PR TITLE
Replace system lambda

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     testImplementation libs.org.junit.jupiter.junit.jupiter
     testImplementation libs.org.assertj.assertj.core
     testImplementation libs.org.mockito.mockito.core
-    testImplementation libs.com.github.stefanbirkner.system.lambda
 
     // Quiet build -- build works without this, but JUnit complains
     testRuntimeOnly libs.org.junit.jupiter.junit.jupiter.engine

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ com-github-spotbugs = "4.8.6"
 com-google-code-findbugs = "3.0.1"
 com-h3xstream-findsecbugs-findsecbugs-plugin = "1.13.0"
 com-puppycrawl-tools-checkstyle = "10.17.0"
-com-stefanbirkner-system-lambda = "1.2.1"
 nl-littlerobots-version-catalog-update-plugin = "0.8.4"
 org-assertj = "3.26.3"
 org-gaul-modernizer = "2.9.0"
@@ -22,7 +21,6 @@ com-github-andygoossens-gradle-modernizer-plugin = "1.9.3"
 
 [libraries]
 com-github-spotbugs-spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "com-github-spotbugs" }
-com-github-stefanbirkner-system-lambda = { module = "com.github.stefanbirkner:system-lambda", version.ref = "com-stefanbirkner-system-lambda" }
 com-google-code-findbugs-findbugs-annotations = { module = "com.google.code.findbugs:findbugs-annotations", version.ref = "com-google-code-findbugs" }
 com-h3xstream-findsecbugs-findsecbugs-plugin = { module = "com.h3xstream.findsecbugs:findsecbugs-plugin", version.ref = "com-h3xstream-findsecbugs-findsecbugs-plugin" }
 com-puppycrawl-tools-checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "com-puppycrawl-tools-checkstyle" }

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@
         <spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
         <spotbugs.version>4.8.6</spotbugs.version>
         <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
-        <system-lambda.version>1.2.1</system-lambda.version>
         <taglist-maven-plugin.version>3.0.0</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
         <spotless.check.skip>true</spotless.check.skip>
@@ -160,12 +159,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
-            <version>${system-lambda.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/integrationTest/java/demo/ApplicationTest.java
+++ b/src/integrationTest/java/demo/ApplicationTest.java
@@ -2,8 +2,7 @@ package demo;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
-import static demo.Application.main;
+import static demo.TerminalContext.captureTerminal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -20,8 +19,8 @@ class ApplicationTest {
      **/
     @Test
     void shouldRun() throws Exception {
-        final var out = tapSystemOutNormalized(() -> {
-            main("Hello", "world!");
+        final var out = captureTerminal(() -> {
+            Application.main("Hello", "world!");
         });
 
         assertThat(out).isEqualTo("TheFoo(label=I AM FOOCUTUS OF BORG)\n");

--- a/src/test/java/demo/ApplicationIT.java
+++ b/src/test/java/demo/ApplicationIT.java
@@ -60,8 +60,10 @@ class ApplicationIT {
      * is a challenge for examples.
      */
     @SuppressWarnings({
+            // We follow JVM statics for out and err which confuses PMD
             "PMD.FinalFieldCouldBeStatic",
-            "PMD.CloseResource", // The code is too complex for PMD to follow
+            // The code is too complex for PMD to follow because of JVM statics
+            "PMD.CloseResource",
     })
     private static class ContextForTerminal implements AutoCloseable {
         /**

--- a/src/test/java/demo/ApplicationIT.java
+++ b/src/test/java/demo/ApplicationIT.java
@@ -2,19 +2,102 @@ package demo;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration test for the application.
  */
-@SuppressWarnings("PMD.AtLeastOneConstructor")
+@SuppressWarnings({
+        "PMD.AtLeastOneConstructor",
+        "PMD.CommentSize" // Complain to PMD, and suppress in config
+})
 class ApplicationIT {
-    /** <strong>Use case</strong>: the application runs normally. */
+    /**
+     * <strong>Use case</strong>: the application runs normally.
+     */
     @Test
-    void shouldRun() throws Exception {
-        final var out = tapSystemOutNormalized(Application::main);
+    void shouldRun() {
+        try (var context = captureTerminal()) {
+            // We could write ContextForTerminal for lambdas, but:
+            // 1. More explicit/natural calls for capture of the console.
+            // 2. Skipping the richer API of system-lambda, the point of this.
+            Application.main();
 
-        assertThat(out).isEqualTo("TheFoo(label=I AM FOOCUTUS OF BORG)\n");
+            assertThat(context.toString())
+                    .isEqualTo("TheFoo(label=I AM FOOCUTUS OF BORG)\n");
+        }
+    }
+
+    private static ContextForTerminal captureTerminal() {
+        return new ContextForTerminal();
+    }
+
+    /**
+     * Replace stdout/stderr to a terminal with capture to an array of bytes
+     * for testing.
+     * Messing with UTF-8 and character encodings is (sensibly) required even
+     * though our tests are all ASCII, and users wanting a richer API can
+     * turn to {@code system-lambda} or other solutions.
+     * <p>
+     * <b>Note</b>: This is an example of comments in the code that should be
+     * pushed up to Javadoc.
+     * Generally, if you need to comment something in the code, then push it
+     * in the Javadoc and help users read your remarks,
+     * or else refactor the code to make the comment irrelevant.
+     * The general pattern is "shift problems left", meaning sooner to
+     * developers: browsing code advice is much to the left of fixing a
+     * problem in production.
+     * <p>
+     * <b>Note</b>: Pay no attention to the multi-threading issues for
+     * parallel tests.
+     * This is a concern always and anytime we use stdout and stderr, and
+     * also with libraries.
+     * Support for older applications on older JVMs that do not assume UTF-8
+     * is a challenge for examples.
+     */
+    @SuppressWarnings({
+            "PMD.FinalFieldCouldBeStatic",
+            "PMD.CloseResource", // The code is too complex for PMD to follow
+    })
+    private static class ContextForTerminal implements AutoCloseable {
+        /**
+         * Combine "stdout" and "stderr" into a single buffer usable in tests.
+         * Note that this does not address UTF-8 concerns, so needs wrapping,
+         * and additional state.
+         */
+        private final ByteArrayOutputStream captureOutAndErr =
+                new ByteArrayOutputStream();
+        /**
+         * Remember the original stdout so we can restore after the test.
+         */
+        private final PrintStream originalOut = System.out;
+        /**
+         * Remember the original stderr so we can restore after the test.
+         */
+        private final PrintStream originalErr = System.err;
+
+        ContextForTerminal() {
+            final var outAndErr =
+                    new PrintStream(captureOutAndErr, true, UTF_8);
+            System.setOut(outAndErr);
+            System.setErr(outAndErr);
+        }
+
+        @Override
+        public void close() {
+            System.out.close(); // Points to the test-only output stream
+            System.err.close(); // Points to the test-only output stream
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+        }
+
+        @Override
+        public String toString() {
+            return captureOutAndErr.toString(UTF_8);
+        }
     }
 }

--- a/src/test/java/demo/ApplicationIT.java
+++ b/src/test/java/demo/ApplicationIT.java
@@ -8,10 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Integration test for the application.
  */
-@SuppressWarnings({
-        "PMD.AtLeastOneConstructor",
-        "PMD.SignatureDeclareThrowsException"
-})
+@SuppressWarnings("PMD.AtLeastOneConstructor")
 class ApplicationIT {
     /** <strong>Use case</strong>: the application runs normally. */
     @Test

--- a/src/test/java/demo/ApplicationIT.java
+++ b/src/test/java/demo/ApplicationIT.java
@@ -2,18 +2,15 @@ package demo;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static demo.TerminalContext.captureTerminal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration test for the application.
  */
 @SuppressWarnings({
+        // PMD does not understand FooIT.java as a test class
         "PMD.AtLeastOneConstructor",
-        "PMD.CommentSize" // Complain to PMD, and suppress in config
 })
 class ApplicationIT {
     /**
@@ -24,90 +21,5 @@ class ApplicationIT {
         final var out = captureTerminal(Application::main);
 
         assertThat(out).isEqualTo("TheFoo(label=I AM FOOCUTUS OF BORG)\n");
-    }
-
-    /**
-     * Wrapper method for a cleaner API.
-     * <p>
-     * If {@code ContextForTerminal} is used for other tests, this method
-     * should be moved into that class as a public static for tests to call.
-     *
-     * @param call typically a method reference or a lambda
-     * @return the captured STDOUT and STDERR
-     */
-    private static String captureTerminal(final Runnable call) {
-        try (var context = new ContextForTerminal()) {
-            call.run();
-            return context.toString();
-        }
-    }
-
-    /**
-     * Replaces STDOUT/STDERR to a terminal with capture to an array of bytes
-     * for testing.
-     * <p>
-     * Messing with UTF-8 and character encodings is (sensibly) required even
-     * though our tests are all ASCII, and users wanting a richer API can
-     * turn to {@code system-lambda} or other solutions.
-     * <p>
-     * <b>Note</b>: This is an example of comments in the code that should be
-     * pushed up to Javadoc.
-     * Generally, if you need to comment something in the code, then push it
-     * in the Javadoc and help users read your remarks,
-     * or else refactor the code to make the comment irrelevant.
-     * The general pattern is "shift problems left", meaning sooner to
-     * developers: browsing code advice is much to the left of fixing a
-     * problem in production.
-     * <p>
-     * <b>Note</b>: Pay no attention to the multi-threading issues for
-     * parallel tests.
-     * This is a concern always and anytime we use STDOUT/STDERR, and also
-     * with libraries.
-     * Support for older applications on older JVMs that do not assume UTF-8
-     * is a challenge for examples.
-     */
-    @SuppressWarnings({
-            // We follow JVM statics for out and err which confuses PMD
-            "PMD.FinalFieldCouldBeStatic",
-            // The code is too complex for PMD to follow because of JVM statics
-            "PMD.CloseResource",
-    })
-    private static class ContextForTerminal implements AutoCloseable {
-        /**
-         * Combine STDOUT/STDERR into a single buffer usable in tests.
-         * <p>
-         * Note that this does not address UTF-8 concerns, so needs wrapping,
-         * and additional state.
-         */
-        private final ByteArrayOutputStream captureOutAndErr =
-                new ByteArrayOutputStream();
-        /**
-         * Remember the original STDOUT so we can restore after the test.
-         */
-        private final PrintStream originalOut = System.out;
-        /**
-         * Remember the original STDERR so we can restore after the test.
-         */
-        private final PrintStream originalErr = System.err;
-
-        ContextForTerminal() {
-            final var outAndErr =
-                    new PrintStream(captureOutAndErr, true, UTF_8);
-            System.setOut(outAndErr);
-            System.setErr(outAndErr);
-        }
-
-        @Override
-        public void close() {
-            System.out.close(); // Points to the test-only output stream
-            System.err.close(); // Points to the test-only output stream
-            System.setOut(originalOut);
-            System.setErr(originalErr);
-        }
-
-        @Override
-        public String toString() {
-            return captureOutAndErr.toString(UTF_8);
-        }
     }
 }

--- a/src/test/java/demo/TerminalContext.java
+++ b/src/test/java/demo/TerminalContext.java
@@ -1,0 +1,92 @@
+package demo;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Replaces STDOUT/STDERR to a terminal with capture to an array of bytes
+ * for testing.
+ * <p>
+ * Messing with UTF-8 and character encodings is (sensibly) required even
+ * though our tests are all ASCII, and users wanting a richer API can
+ * turn to {@code system-lambda} or other solutions.
+ * <p>
+ * <b>Note</b>: This is an example of comments in the code that should be
+ * pushed up to Javadoc.
+ * Generally, if you need to comment something in the code, then push it
+ * in the Javadoc and help users read your remarks,
+ * or else refactor the code to make the comment irrelevant.
+ * The general pattern is "shift problems left", meaning sooner to
+ * developers: browsing code advice is much to the left of fixing a
+ * problem in production.
+ * <p>
+ * <b>Note</b>: Pay no attention to the multi-threading issues for
+ * parallel tests.
+ * This is a concern always and anytime we use STDOUT/STDERR, and also
+ * with libraries.
+ * Support for older applications on older JVMs that do not assume UTF-8
+ * is a challenge for examples.
+ */
+@SuppressWarnings({
+        // We follow JVM statics for out and err which confuses PMD
+        "PMD.FinalFieldCouldBeStatic",
+        // The code is too complex for PMD to follow because of JVM statics
+        "PMD.CloseResource",
+        "PMD.CommentSize" // Complain to PMD, and suppress in config
+})
+final class TerminalContext implements AutoCloseable {
+    /**
+     * Combine STDOUT/STDERR into a single buffer usable in tests.
+     * <p>
+     * Note that this does not address UTF-8 concerns, so needs wrapping,
+     * and additional state.
+     */
+    private final ByteArrayOutputStream captureOutAndErr =
+            new ByteArrayOutputStream();
+    /**
+     * Remember the original STDOUT so we can restore after the test.
+     */
+    private final PrintStream originalOut = System.out;
+    /**
+     * Remember the original STDERR so we can restore after the test.
+     */
+    private final PrintStream originalErr = System.err;
+
+    private TerminalContext() {
+        final var outAndErr =
+                new PrintStream(captureOutAndErr, true, UTF_8);
+        System.setOut(outAndErr);
+        System.setErr(outAndErr);
+    }
+
+    /**
+     * Wrapper method for a cleaner API.
+     * <p>
+     * If {@code TerminalContext} is used for other tests, this method
+     * should be moved into that class as a public static for tests to call.
+     *
+     * @param call typically a method reference or a lambda
+     * @return the captured STDOUT and STDERR
+     */
+    static String captureTerminal(final Runnable call) {
+        try (var context = new TerminalContext()) {
+            call.run();
+            return context.toString();
+        }
+    }
+
+    @Override
+    public void close() {
+        System.out.close(); // Points to the test-only output stream
+        System.err.close(); // Points to the test-only output stream
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    @Override
+    public String toString() {
+        return captureOutAndErr.toString(UTF_8);
+    }
+}

--- a/src/test/java/demo/TerminalContext.java
+++ b/src/test/java/demo/TerminalContext.java
@@ -11,7 +11,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p>
  * Messing with UTF-8 and character encodings is (sensibly) required even
  * though our tests are all ASCII, and users wanting a richer API can
- * turn to {@code system-lambda} or other solutions.
+ * turn to {@code system-lambda} or similar libraries.
  * <p>
  * <b>Note</b>: This is an example of comments in the code that should be
  * pushed up to Javadoc.
@@ -28,6 +28,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * with libraries.
  * Support for older applications on older JVMs that do not assume UTF-8
  * is a challenge for examples.
+ *
+ * @see <a
+ * href="https://github.com/stefanbirkner/system-lambda">system-lambda</a>
  */
 @SuppressWarnings({
         // We follow JVM statics for out and err which confuses PMD

--- a/src/test/java/demo/TerminalContext.java
+++ b/src/test/java/demo/TerminalContext.java
@@ -32,7 +32,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
         "PMD.FinalFieldCouldBeStatic",
         // The code is too complex for PMD to follow because of JVM statics
         "PMD.CloseResource",
-        "PMD.CommentSize" // Complain to PMD, and suppress in config
+        // File issue with PMD, and suppress in config.
+        // Why is long Javadoc triggering this?
+        "PMD.CommentSize"
 })
 final class TerminalContext implements AutoCloseable {
     /**

--- a/src/test/java/demo/TerminalContext.java
+++ b/src/test/java/demo/TerminalContext.java
@@ -24,8 +24,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * tests in parallel: their output to the terminal will become interleaved.
  * This is a concern always and anytime we use STDOUT/STDERR.
  *
+ * @see TerminalContext#captureTerminal() the main entry point for this class
  * @see <a
- * href="https://github.com/stefanbirkner/system-lambda">system-lambda</a>
+ * href="https://github.com/stefanbirkner/system-lambda"><code>system-lambda
+ * </code> for more sophisticated handling of STDOUT/STDERR</a>
  */
 @SuppressWarnings({
         // We follow JVM statics for out and err which confuses PMD
@@ -34,8 +36,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
         "PMD.CloseResource",
         // File issue with PMD, and suppress in config.
         // Why is long Javadoc triggering this?
-        "PMD.CommentSize"
-})
+        "PMD.CommentSize"})
 final class TerminalContext implements AutoCloseable {
     /**
      * Combine STDOUT/STDERR into a single buffer usable in tests.
@@ -43,8 +44,8 @@ final class TerminalContext implements AutoCloseable {
      * Note that this does not address UTF-8 concerns, so needs wrapping,
      * and additional state.
      */
-    private final ByteArrayOutputStream captureOutAndErr =
-            new ByteArrayOutputStream();
+    private final ByteArrayOutputStream captureOutAndErr
+            = new ByteArrayOutputStream();
     /**
      * Remember the original STDOUT so we can restore after the test.
      */
@@ -61,10 +62,9 @@ final class TerminalContext implements AutoCloseable {
     }
 
     /**
-     * Wrapper method for a cleaner API.
-     * <p>
-     * If {@code TerminalContext} is used for other tests, this method
-     * should be moved into that class as a public static for tests to call.
+     * Main entry point for using {@code TerminalCapture}. Use this call in
+     * tests to capture STDOUT/STDERR, and restore them after the test
+     * completes.
      *
      * @param call typically a method reference or a lambda
      * @return the captured STDOUT and STDERR

--- a/src/test/java/demo/TerminalContext.java
+++ b/src/test/java/demo/TerminalContext.java
@@ -9,6 +9,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Replaces STDOUT/STDERR to a terminal with capture to an array of bytes
  * for testing.
  * <p>
+ * One does not usually test STDOUT/STDERR output unless working on a terminal
+ * program.
+ * This example project does so to demonstrate <em>integration testing</em> as
+ * there are no complex interactions to otherwise test in the project, but it
+ * is important to demonstrate constrasting tests between <em>unit tests</em>
+ * and <em>integration tests</em>.
+ * <p>
  * Messing with UTF-8 and character encodings is (sensibly) required even
  * though our tests are all ASCII, and users wanting a richer API can
  * turn to {@code system-lambda} or similar libraries.

--- a/src/test/java/demo/TerminalContext.java
+++ b/src/test/java/demo/TerminalContext.java
@@ -20,21 +20,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * though our tests are all ASCII, and users wanting a richer API can
  * turn to {@code system-lambda} or similar libraries.
  * <p>
- * <b>Note</b>: This is an example of comments in the code that should be
- * pushed up to Javadoc.
- * Generally, if you need to comment something in the code, then push it
- * in the Javadoc and help users read your remarks,
- * or else refactor the code to make the comment irrelevant.
- * The general pattern is "shift problems left", meaning sooner to
- * developers: browsing code advice is much to the left of fixing a
- * problem in production.
- * <p>
- * <b>Note</b>: Pay no attention to the multi-threading issues for
- * parallel tests.
- * This is a concern always and anytime we use STDOUT/STDERR, and also
- * with libraries.
- * Support for older applications on older JVMs that do not assume UTF-8
- * is a challenge for examples.
+ * <b>Note</b>: Use of this test helper means: do <b>not</b> run integration
+ * tests in parallel: their output to the terminal will become interleaved.
+ * This is a concern always and anytime we use STDOUT/STDERR.
  *
  * @see <a
  * href="https://github.com/stefanbirkner/system-lambda">system-lambda</a>
@@ -65,10 +53,9 @@ final class TerminalContext implements AutoCloseable {
     private final PrintStream originalErr = System.err;
 
     private TerminalContext() {
-        final var outAndErr =
-                new PrintStream(captureOutAndErr, true, UTF_8);
-        System.setOut(outAndErr);
-        System.setErr(outAndErr);
+        final var outAndErr = new PrintStream(captureOutAndErr, true, UTF_8);
+        System.setOut(outAndErr); // NOT thread-safe
+        System.setErr(outAndErr); // NOT thread-safe
     }
 
     /**

--- a/src/test/java/demo/TerminalContext.java
+++ b/src/test/java/demo/TerminalContext.java
@@ -25,8 +25,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <b>Note</b>: Use of this test helper means: do <b>not</b> run integration
  * tests in parallel: their output to the terminal will become interleaved.
  * This is a concern always and anytime you access STDOUT/STDERR.
+ * <b>Note</b>: A recommended pattern is that a class initializes as much as
+ * possible in the fields so that the constructor has minimal work.
  *
- * @see TerminalContext#captureTerminal() the main entry point for this class
+ * @see TerminalContext#captureTerminal(Runnable) the main entry point for this
+ * class
  * @see <a
  * href="https://github.com/stefanbirkner/system-lambda"><code>system-lambda
  * </code> for more sophisticated handling of STDOUT/STDERR</a>
@@ -39,7 +42,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
         // File issue with PMD, and suppress in config.
         // Why is long Javadoc triggering this?
         "PMD.CommentSize"})
-final class TerminalContext implements AutoCloseable {
+public final class TerminalContext implements AutoCloseable {
     /**
      * Combine STDOUT/STDERR into a single buffer usable in tests.
      * <p>
@@ -64,14 +67,16 @@ final class TerminalContext implements AutoCloseable {
     }
 
     /**
-     * Main entry point for using {@code TerminalCapture}. Use this call in
-     * tests to capture STDOUT/STDERR, and restore them after the test
-     * completes.
+     * Runs the call provided to capture STDOUT/STDERR such as {@code main}.
+     * Use this in tests to check STDOUT/STDERR, and restore those after the
+     * test completes. Note that outut is captured as UTF-8.
      *
-     * @param call typically a method reference or a lambda
-     * @return the captured STDOUT and STDERR
+     * @param call the method reference or lambda to execute and capture
+     * STDOUT/STDERR from
+     * @return the captured STDOUT and STDERR as a UTF-8 string, including
+     * possibly interleaved output
      */
-    static String captureTerminal(final Runnable call) {
+    public static String captureTerminal(final Runnable call) {
         try (var context = new TerminalContext()) {
             call.run();
             return context.toString();

--- a/src/test/java/demo/TerminalContext.java
+++ b/src/test/java/demo/TerminalContext.java
@@ -6,23 +6,25 @@ import java.io.PrintStream;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * Replaces STDOUT/STDERR to a terminal with capture to an array of bytes
- * for testing.
+ * Replaces writing to STDOUT/STDERR with capture to an array of bytes all for
+ * testing.
  * <p>
  * One does not usually test STDOUT/STDERR output unless working on a terminal
  * program.
- * This example project does so to demonstrate <em>integration testing</em> as
- * there are no complex interactions to otherwise test in the project, but it
- * is important to demonstrate constrasting tests between <em>unit tests</em>
- * and <em>integration tests</em>.
+ * This example project does so to demonstrate <em>integration testing</em>.
+ * We do not want to focus on complex alternatives (databases, dependency
+ * injection, remote REST calls, et al) but it is important to demonstrate
+ * contrast between <em>unit tests</em> and <em>integration tests</em> in the
+ * build.
  * <p>
- * Messing with UTF-8 and character encodings is (sensibly) required even
- * though our tests are all ASCII, and users wanting a richer API can
- * turn to {@code system-lambda} or similar libraries.
+ * <b>Note</b>: Mucking with UTF-8/character encodings is required in this
+ * code even though our tests are all ASCII, and users wanting a richer API
+ * can turn to {@code system-lambda} or similar libraries. Anytime you work
+ * with text for humans, keep UTF and encodings in mind.
  * <p>
  * <b>Note</b>: Use of this test helper means: do <b>not</b> run integration
  * tests in parallel: their output to the terminal will become interleaved.
- * This is a concern always and anytime we use STDOUT/STDERR.
+ * This is a concern always and anytime you access STDOUT/STDERR.
  *
  * @see TerminalContext#captureTerminal() the main entry point for this class
  * @see <a


### PR DESCRIPTION
Howdy!
I'm looking to replace the `system-lambda` test library with small, local, bespoke code. This library specializes in nicer Java code for messing with `System` globals in the JVM such as STDOUT/STDERR, et al.
This addresses https://github.com/binkley/modern-java-practices/issues/483. Currently the build on this branch is **green**.

**To consider before approving**:
Should the project provide example replacement code rather than continuing to use a 3rd-party library?

Use a code style that:
- Maximizes teaching, such as a lot of Javadoc: it isn't good enough to "just work", but should help others see the practices and patterns<sup>[1]</sup>
- Is a drop-in replacement for `system-lambda` with improved naming: `captureTerminal` (this code) _vs_ `tapSystemOutNormalized` (system-lambda library) (Expected discussion on naming for "captureTerminal" -- all TWers love noodling on naming 😀)
- Hides internal details as much as possible (a lesson for readers) to lower the surface area of the API. The replacement class is `TerminalContext` and only the static method of `captureTerminal` should be visible. Do not look behind the curtain: we mess with JDK global statics)

@Bukharovsi GitHub auto-suggested you to review. `:D` We won't depend on your feedback to decide if to merge this PR--there is a lot on your plate right now--, but would love your thoughts!

I really like the https://github.com/stefanbirkner/system-lambda library, and use it in some side projects where I need to test complicated things about the terminal or environment. For the example code in this project, it feels like using a cannon to hit an orange.

#### Footnotes
1. Essentially what this PR and a library like `system-lambda` does is to wrap a continuation (the call to test). Describing it this way is unhelpful for most programmers. We are wrapping calls (`Application.main`) that access monads for STDOUT and STDERR (such a scholarly description meaning "side effect"), and capturing the data sent to them so we can test these interactions.
   Yep, this is what testing "Hello, world" looks like! No way I want to talk about it this way to the general programmer audience.